### PR TITLE
llvm-rc-wrapper - handle all llvm-rc args.

### DIFF
--- a/llvm-rc-wrapper
+++ b/llvm-rc-wrapper
@@ -7,6 +7,14 @@ while [ $# -gt 1 ]; do
   param=$1
   shift
   case "$param" in
+    -c*|/c*)
+      if [ "${#param}" -eq 2 ]; then
+        llvm_rc_args+=("/C" "$1")
+        shift
+      else
+        llvm_rc_args+=("/C" "${param:2}")
+      fi
+      ;;
     -d*|/d*)
       if [ "${#param}" -eq 2 ]; then
         llvm_rc_args+=("/D" "$1")
@@ -15,12 +23,44 @@ while [ $# -gt 1 ]; do
         llvm_rc_args+=("/D" "${param:2}")
       fi
       ;;
+    -fo*|/fo*)
+      if [ "${#param}" -eq 3 ]; then
+        llvm_rc_args+=("/FO" "$1")
+        shift
+      else
+        llvm_rc_args+=("/FO" "${param:3}")
+      fi
+      ;;
+    -i*|/i*)
+      if [ "${#param}" -eq 2 ]; then
+        llvm_rc_args+=("/I" "$1")
+        shift
+      else
+        llvm_rc_args+=("/I" "${param:2}")
+      fi
+      ;;
+    -ln*|/ln*)
+      if [ "${#param}" -eq 3 ]; then
+        llvm_rc_args+=("/LN" "$1")
+        shift
+      else
+        llvm_rc_args+=("/LN" "${param:3}")
+      fi
+      ;;
     -l*|/l*)
       if [ "${#param}" -eq 2 ]; then
         llvm_rc_args+=("/l" "$1")
         shift
       else
         llvm_rc_args+=("/l" "${param:2}")
+      fi
+      ;;
+    -u*|/u*)
+      if [ "${#param}" -eq 2 ]; then
+        llvm_rc_args+=("/U" "$1")
+        shift
+      else
+        llvm_rc_args+=("/U" "${param:2}")
       fi
       ;;
     *) llvm_rc_args+=("$param");;


### PR DESCRIPTION
Tested with the following command
`./llvm-rc-wrapper -c/dir -c /dir -d/dir -d /dir -fo/dir -fo /dir -i/dir -i /dir -ln/dir -ln /dir -l/dir -l /dir -u/dir -u /dir rc-file`
Patched llvm-rc-wrapper generated
`
llvm-rc- /C /dir /C /dir /D /dir /D /dir /FO /dir /FO /dir /I /dir /I /dir /LN /dir /LN /dir /l /dir /l /dir /U /dir /U /dir rc-file
`

Fixes #1 